### PR TITLE
Auto-Merge abort and better error detection

### DIFF
--- a/src/ShinyDeploy/Domain/Deployment.php
+++ b/src/ShinyDeploy/Domain/Deployment.php
@@ -120,13 +120,8 @@ class Deployment extends Domain
         }
 
         $this->logResponder->log('Checking repository status...');
-        $isRepoStatusCorrupted = false;
-        if ($this->checkRepoStatus($isRepoStatusCorrupted) === false) {
-            $this->logResponder->error('Repository status check failed. Aborting job.');
-            return false;
-        }
 
-        if ($isRepoStatusCorrupted) {
+        if ($this->checkRepoStatusIsCorrupted()) {
             $this->logResponder->log('Reset corrupted repository status by resetting...');
 
             if ($this->resetRepoStatus() === false) {
@@ -205,8 +200,7 @@ class Deployment extends Domain
         if ($listMode === false && $this->runTasks('after') === false) {
             $this->logResponder->error('Running tasks failed. Aborting job.');
 
-            $isRepoStatusCorrupted = false;
-            $this->checkRepoStatus($isRepoStatusCorrupted);
+            $isRepoStatusCorrupted = $this->checkRepoStatusIsCorrupted();
 
             if ($isRepoStatusCorrupted === false) {
                 return false;
@@ -214,7 +208,7 @@ class Deployment extends Domain
 
             $this->logResponder->info('Repository detected corrupted, try to reset.');
 
-            if ($isRepoStatusCorrupted && $this->resetRepoStatus() !== false) {
+            if ($this->resetRepoStatus() !== false) {
                 $this->logResponder->success('Repository was resetted.');
             } else {
                 $this->logResponder->error('Repository could not be resetted. Please check the logs');
@@ -477,9 +471,9 @@ class Deployment extends Domain
         return $this->repository->switchBranch($this->data['branch']);
     }
 
-    protected function checkRepoStatus(bool &$isRepoCorrupted): bool
+    protected function checkRepoStatusIsCorrupted(): bool
     {
-        return $this->repository->checkRepoStatus($isRepoCorrupted);
+        return $this->repository->checkRepoStatusIsCorrupted();
     }
 
     protected function resetRepoStatus(): bool

--- a/src/ShinyDeploy/Domain/Git.php
+++ b/src/ShinyDeploy/Domain/Git.php
@@ -8,8 +8,6 @@ use ShinyDeploy\Exceptions\MissingDataException;
 
 class Git extends Domain
 {
-    private array $mergeAbort = [];
-
     /**
      * Gets git version. Used to check if git is available.
      *

--- a/src/ShinyDeploy/Domain/Git.php
+++ b/src/ShinyDeploy/Domain/Git.php
@@ -8,6 +8,8 @@ use ShinyDeploy\Exceptions\MissingDataException;
 
 class Git extends Domain
 {
+    private array $mergeAbort = [];
+
     /**
      * Gets git version. Used to check if git is available.
      *
@@ -116,14 +118,14 @@ class Git extends Domain
         }
     }
 
-     /**
+    /**
      * Gets revision (latest commit hash) of remote repository.
      *
      * @param string $repoPath
      * @param string $repoUrl
      * @param string $branch
      * @return string
-      * @throws \RuntimeException
+     * @throws \RuntimeException
      */
     public function getRemoteRepositoryRevision(string $repoPath, string $repoUrl, string $branch): string
     {
@@ -391,6 +393,7 @@ class Git extends Domain
      * Executes a git command and returns response.
      *
      * @param string $command
+     * @param bool $checkForConflicts flag to allow to search for merge conflicts during exec
      * @throws GitException
      * @return string
      */
@@ -400,10 +403,72 @@ class Git extends Domain
         $command = escapeshellcmd($command) . ' 2>&1';
         exec($command, $output, $exitCode);
         $response = implode("\n", $output) ?? '';
+
         if ($exitCode !== 0) {
             throw new GitException('Git command exited with non zero return code. Git output: ' . $response);
         }
 
         return $response;
+    }
+
+    public function isMergeInProgress(): bool
+    {
+        $command = 'GIT_TERMINAL_PROMPT=0 git merge HEAD';
+        $command = escapeshellcmd($command) . ' 2>&1';
+
+        exec($command, $output, $exitCode);
+
+        if ($exitCode !== 0) {
+            return true;
+        }
+
+        if (count($output) !== 1) {
+            return true;
+        }
+
+        foreach ($output as $message) {
+            if (in_array($message, [
+                'error: Merging is not possible because you have unmerged files.',
+                'error: Pulling is not possible because you have unmerged files.',
+                'error: you need to resolve your current index first',
+                'hint: Fix them up in the work tree, and then use \'git add/rm <file>\'',
+                'hint: as appropriate to mark resolution and make a commit.',
+                'fatal: Exiting because of an unresolved conflict.',
+            ])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function handleMergeAbort(): bool
+    {
+        try {
+            $this->exec('merge --abort');
+            return true;
+        } catch (GitException $e) {
+            $this->logger->error('Git auto-merge abort failed.' . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * @param string $newBranchName comes from DB 'deployments.branch' (we are currently in 'deployments.target_branch')
+     * @return bool
+     */
+    public function forcedAutoMerge(string $newBranchName): bool
+    {
+        try {
+            if (empty($newBranchName)) {
+                throw new GitException('Branch to merge cannot be empty');
+            }
+
+            $this->exec('merge -X theirs ' . $newBranchName);
+            return true;
+        } catch (GitException $e) {
+            $this->logger->error('Git forced merge-command failed.' . $e->getMessage());
+            return false;
+        }
     }
 }

--- a/src/ShinyDeploy/Domain/Repository.php
+++ b/src/ShinyDeploy/Domain/Repository.php
@@ -120,10 +120,9 @@ class Repository extends Domain
         return false;
     }
 
-    public function checkRepoStatus(bool &$isRepoCorrupted): bool
+    public function checkRepoStatusIsCorrupted(): bool
     {
-        $isRepoCorrupted = $this->git->isMergeInProgress();
-        return true;
+        return $this->git->isMergeInProgress();
     }
 
     public function resetRepoStatus(): bool

--- a/src/ShinyDeploy/Domain/Repository.php
+++ b/src/ShinyDeploy/Domain/Repository.php
@@ -120,6 +120,22 @@ class Repository extends Domain
         return false;
     }
 
+    public function checkRepoStatus(bool &$isRepoCorrupted): bool
+    {
+        $isRepoCorrupted = $this->git->isMergeInProgress();
+        return true;
+    }
+
+    public function resetRepoStatus(): bool
+    {
+        return $this->git->handleMergeAbort();
+    }
+
+    public function forcedAutoMerge($localRevision): bool
+    {
+        return $this->git->forcedAutoMerge($localRevision);
+    }
+
     /**
      * Removes old branches from repository.
      *

--- a/src/ShinyDeploy/Domain/Repository.php
+++ b/src/ShinyDeploy/Domain/Repository.php
@@ -130,11 +130,6 @@ class Repository extends Domain
         return $this->git->handleMergeAbort();
     }
 
-    public function forcedAutoMerge($localRevision): bool
-    {
-        return $this->git->forcedAutoMerge($localRevision);
-    }
-
     /**
      * Removes old branches from repository.
      *

--- a/src/ShinyDeploy/Domain/Repository.php
+++ b/src/ShinyDeploy/Domain/Repository.php
@@ -120,7 +120,7 @@ class Repository extends Domain
         return false;
     }
 
-    public function checkRepoStatusIsCorrupted(): bool
+    public function repoStatusIsCurrupted(): bool
     {
         return $this->git->isMergeInProgress();
     }


### PR DESCRIPTION
Resets an auto-merge, if the deployment had an error and the git status is hanging in an active merge (by unresolved conflicts). 
We do this in the beginning of a deployment and after completing the repo-tasks to be safe being always on a working branch/repo after a deployment, even if there was an error. 